### PR TITLE
Expand arrays to single word when calling check_changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ if [[ $rc -ne 0 ]]; then
     exit 0
 fi
 
-has_changes=$(check_changes "$CHANGED_FILES" "${PATTERNS[@]}" "${IGNORE_PATTERNS[@]}")
+has_changes=$(check_changes "$CHANGED_FILES" "${PATTERNS[*]}" "${IGNORE_PATTERNS[*]}")
 
 if $has_changes; then
     echo "Setting 'has_changes' to 'yes'"


### PR DESCRIPTION
Otherwise array contents are passed as individual words and the input
parameters are mangled and lost.

Fixes #7

Signed-off-by: Antonin Bas <abas@vmware.com>