### PR TITLE
Set repo directory as safe in the git global config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 source $THIS_DIR/check_changes.sh
 
+# See https://github.com/actions/checkout/issues/760
+echo "Adding repository directory to the git global config as a safe directory"
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 cat "$GITHUB_EVENT_PATH"
 
 PR_BASE_SHA=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
About a month ago a Git security vulnerability was annouced:
https://github.blog/2022-04-12-git-security-vulnerability-announced/
The security patch to address this vulnerability prevents Git from
looking at .git folders owned by other users, unless these directories
are added to a "safe" list in the Git config.
This Github Action uses a Docker container based on Ubuntu 20.04, and
the version of Git shipped with Ubuntu 20.04 was also patched. As a
result, it is now necessary for this Action to set the repo directory as
safe *inside the container*, given that the owner of the repo directory
(Github runner user) is different from the Docker user
(root). Otherwise, all Git commands fail.

See also https://github.com/actions/checkout/issues/760.

Fixes #9

Signed-off-by: Antonin Bas <abas@vmware.com>