### PR TITLE
chore: remove redundant enabled: true from renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,20 +29,19 @@
     {
       matchManagers: ["dockerfile"],
       addLabels: ["docker"],
-      enabled: true,
     },
 
+    // Only update the image sha, but not the tag
     {
       matchManagers: ["dockerfile"],
       matchPackageNames: ["ubuntu"],
       matchUpdateTypes: ["major", "minor"],
-      enabled: false, // this should update the image sha, but not the tag
+      enabled: false,
     },
 
     {
       matchManagers: ["github-actions"],
       addLabels: ["github_actions"],
-      enabled: true,
     },
   ],
 }


### PR DESCRIPTION
Removes redundant `enabled: true` declarations from Renovate configuration for cleaner, more consistent config.